### PR TITLE
Feature/paginate lists

### DIFF
--- a/kongclient/api/base.py
+++ b/kongclient/api/base.py
@@ -30,6 +30,8 @@ class Manager:
             next_url = None
         while next_url is not None:
             resp = self.api.client.get(url=next_url)
+            if resp.status_code != 200:
+                raise APIException(http_status=resp.status_code, message=resp.text, method='GET', url=resp.request.url)
             result += resp.json()[response_key]
             next_url = resp.json()['next']
         return result

--- a/kongclient/api/base.py
+++ b/kongclient/api/base.py
@@ -24,6 +24,14 @@ class Manager:
         if resp.status_code != 200:
             raise APIException(http_status=resp.status_code, message=resp.text, method='GET', url=resp.request.url)
         body = resp.json()
+        try:
+            next_url = body['next']
+        except KeyError:
+            next_url = None
+        while next_url is not None:
+            resp = self.api.client.get(url=next_url)
+            body[response_key] += resp.json()[response_key]
+            next_url = resp.json()['next']
         return body[response_key]
 
     def _get(self, url):

--- a/kongclient/api/base.py
+++ b/kongclient/api/base.py
@@ -23,16 +23,16 @@ class Manager:
         resp = self.api.client.get(url=url)
         if resp.status_code != 200:
             raise APIException(http_status=resp.status_code, message=resp.text, method='GET', url=resp.request.url)
-        body = resp.json()
+        result = resp.json()[response_key]
         try:
-            next_url = body['next']
+            next_url = resp.json()['next']
         except KeyError:
             next_url = None
         while next_url is not None:
             resp = self.api.client.get(url=next_url)
-            body[response_key] += resp.json()[response_key]
+            result += resp.json()[response_key]
             next_url = resp.json()['next']
-        return body[response_key]
+        return result
 
     def _get(self, url):
         """ Get an object from collection.


### PR DESCRIPTION
If more than 100 routes, services, consumers, etc. are returned when listing them through the Kong admin API, only the first page of results are returned. This change automatically pages through results if there's more than one page and returns a single list of all results